### PR TITLE
2160分辨率不能领取代币问题

### DIFF
--- a/New Car Unleashed.js
+++ b/New Car Unleashed.js
@@ -102,8 +102,8 @@ var profile2160 = {
     },
 
     countdown: {
-        x: 160,
-        y: 224
+        x: 123,
+        y: 300
     },
 
     left: { x: 961, y: 730 },


### PR DESCRIPTION
2160分辨率活动首页的倒数坐标错了，改成 123,300即可正常运行